### PR TITLE
🐛 Cap PennyLane version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       build-project: true
       files-changed-only: true
       setup-python: true
-      install-pkgs: "pennylane-catalyst==0.14.1"
+      install-pkgs: "pennylane-catalyst==0.14.1 pennylane~=0.44.1"
       cpp-linter-extra-args: "-std=c++20"
       setup-mlir: true
       llvm-version: "113f01aa82d055410f22a9d03b3468fa68600589"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       build-project: true
       files-changed-only: true
       setup-python: true
-      install-pkgs: "pennylane-catalyst==0.14.1 pennylane~=0.44.1"
+      install-pkgs: "pennylane-catalyst==0.14.1,pennylane==0.44.1"
       cpp-linter-extra-args: "-std=c++20"
       setup-mlir: true
       llvm-version: "113f01aa82d055410f22a9d03b3468fa68600589"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Changed
 
-- 📌 Pin PennyLane to the Catalyst v0.14.1-compatible <0.45 versions
+- 📌 Pin PennyLane to the Catalyst v0.14.1-compatible 0.44 series
 - ⬆️ Update Catalyst to version 0.14.1 ([#77]) ([**@denialhaag**])
 
 ## [1.0.0] - 2026-01-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Changed
 
-- 📌 Pin PennyLane to the Catalyst v0.14.1-compatible 0.44 series
+- 📌 Pin PennyLane to the Catalyst v0.14.1-compatible <0.45 versions
 - ⬆️ Update Catalyst to version 0.14.1 ([#77]) ([**@denialhaag**])
 
 ## [1.0.0] - 2026-01-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Changed
 
+- 📌 Pin PennyLane to the Catalyst v0.14.1-compatible 0.44 series
 - ⬆️ Update Catalyst to version 0.14.1 ([#77]) ([**@denialhaag**])
 
 ## [1.0.0] - 2026-01-26

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires = [
   "scikit-build-core>=0.12.2",
   "setuptools-scm>=9.2.2",
   "pennylane-catalyst~=0.14.1",
-  "pennylane<0.45",
+  "pennylane>=0.44.1,<0.45",
 ]
 build-backend = "scikit_build_core.build"
 
@@ -49,7 +49,7 @@ requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
   "pennylane-catalyst~=0.14.1",
-  "pennylane<0.45",
+  "pennylane>=0.44.1,<0.45",
 ]
 
 [project.urls]
@@ -287,7 +287,7 @@ build = [
   "scikit-build-core>=0.12.2",
   "setuptools-scm>=9.2.2",
   "pennylane-catalyst~=0.14.1",
-  "pennylane<0.45",
+  "pennylane>=0.44.1,<0.45",
 ]
 docs = [
   "furo>=2025.12.19",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires = [
   "scikit-build-core>=0.12.2",
   "setuptools-scm>=9.2.2",
   "pennylane-catalyst~=0.14.1",
-  "pennylane>=0.44.1,<0.45",
+  "pennylane<0.45",
 ]
 build-backend = "scikit_build_core.build"
 
@@ -49,7 +49,7 @@ requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
   "pennylane-catalyst~=0.14.1",
-  "pennylane>=0.44.1,<0.45",
+  "pennylane<0.45",
 ]
 
 [project.urls]
@@ -287,7 +287,7 @@ build = [
   "scikit-build-core>=0.12.2",
   "setuptools-scm>=9.2.2",
   "pennylane-catalyst~=0.14.1",
-  "pennylane>=0.44.1,<0.45",
+  "pennylane<0.45",
 ]
 docs = [
   "furo>=2025.12.19",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires = [
   "scikit-build-core>=0.12.2",
   "setuptools-scm>=9.2.2",
   "pennylane-catalyst~=0.14.1",
+  "pennylane>=0.44.1,<0.45",
 ]
 build-backend = "scikit_build_core.build"
 
@@ -48,6 +49,7 @@ requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
   "pennylane-catalyst~=0.14.1",
+  "pennylane>=0.44.1,<0.45",
 ]
 
 [project.urls]
@@ -285,6 +287,7 @@ build = [
   "scikit-build-core>=0.12.2",
   "setuptools-scm>=9.2.2",
   "pennylane-catalyst~=0.14.1",
+  "pennylane>=0.44.1,<0.45",
 ]
 docs = [
   "furo>=2025.12.19",

--- a/uv.lock
+++ b/uv.lock
@@ -1028,20 +1028,20 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "pennylane", specifier = "<0.45" },
+    { name = "pennylane", specifier = ">=0.44.1,<0.45" },
     { name = "pennylane-catalyst", specifier = "~=0.14.1" },
 ]
 
 [package.metadata.requires-dev]
 build = [
-    { name = "pennylane", specifier = "<0.45" },
+    { name = "pennylane", specifier = ">=0.44.1,<0.45" },
     { name = "pennylane-catalyst", specifier = "~=0.14.1" },
     { name = "scikit-build-core", specifier = ">=0.12.2" },
     { name = "setuptools-scm", specifier = ">=9.2.2" },
 ]
 dev = [
     { name = "nox", specifier = ">=2025.11.12" },
-    { name = "pennylane", specifier = "<0.45" },
+    { name = "pennylane", specifier = ">=0.44.1,<0.45" },
     { name = "pennylane-catalyst", specifier = "~=0.14.1" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "pytest-console-scripts", specifier = ">=1.4.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -1028,20 +1028,20 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "pennylane", specifier = ">=0.44.1,<0.45" },
+    { name = "pennylane", specifier = "<0.45" },
     { name = "pennylane-catalyst", specifier = "~=0.14.1" },
 ]
 
 [package.metadata.requires-dev]
 build = [
-    { name = "pennylane", specifier = ">=0.44.1,<0.45" },
+    { name = "pennylane", specifier = "<0.45" },
     { name = "pennylane-catalyst", specifier = "~=0.14.1" },
     { name = "scikit-build-core", specifier = ">=0.12.2" },
     { name = "setuptools-scm", specifier = ">=9.2.2" },
 ]
 dev = [
     { name = "nox", specifier = ">=2025.11.12" },
-    { name = "pennylane", specifier = ">=0.44.1,<0.45" },
+    { name = "pennylane", specifier = "<0.45" },
     { name = "pennylane-catalyst", specifier = "~=0.14.1" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "pytest-console-scripts", specifier = ">=1.4.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -978,17 +978,20 @@ wheels = [
 name = "mqt-core-plugins-catalyst"
 source = { editable = "." }
 dependencies = [
+    { name = "pennylane", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
     { name = "pennylane-catalyst", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
 ]
 
 [package.dev-dependencies]
 build = [
+    { name = "pennylane", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
     { name = "pennylane-catalyst", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
     { name = "scikit-build-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
     { name = "setuptools-scm", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
 ]
 dev = [
     { name = "nox", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
+    { name = "pennylane", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
     { name = "pennylane-catalyst", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
     { name = "pytest", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
     { name = "pytest-console-scripts", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
@@ -1024,16 +1027,21 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pennylane-catalyst", specifier = "~=0.14.1" }]
+requires-dist = [
+    { name = "pennylane", specifier = ">=0.44.1,<0.45" },
+    { name = "pennylane-catalyst", specifier = "~=0.14.1" },
+]
 
 [package.metadata.requires-dev]
 build = [
+    { name = "pennylane", specifier = ">=0.44.1,<0.45" },
     { name = "pennylane-catalyst", specifier = "~=0.14.1" },
     { name = "scikit-build-core", specifier = ">=0.12.2" },
     { name = "setuptools-scm", specifier = ">=9.2.2" },
 ]
 dev = [
     { name = "nox", specifier = ">=2025.11.12" },
+    { name = "pennylane", specifier = ">=0.44.1,<0.45" },
     { name = "pennylane-catalyst", specifier = "~=0.14.1" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "pytest-console-scripts", specifier = ">=1.4.1" },


### PR DESCRIPTION
## Description

This PR caps the PennyLane version to <0.45

The reason for this change is that CI started failing with `pennylane-catalyst==0.14.1`, which allows `pennylane>=0.44.1` without an upper bound. Fresh builds can therefore resolve `pennylane==0.45.0`, but Catalyst 0.14.1 still imports `pennylane.transforms.core.transform_dispatcher`, which was removed in PennyLane 0.45.

This change adds an explicit `pennylane<0.45` constraint.

Assisted-by: GPT-5.5 via Codex

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core-plugins-catalyst/blob/main/docs/ai_usage.md).
- [ ] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
